### PR TITLE
Changes to clear out library clashes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,20 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation('org.springframework.boot:spring-boot-starter-web') {
+		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+	}
+	implementation('org.springframework.boot:spring-boot-starter-data-jpa') {
+		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+	}
+	implementation('org.springframework.boot:spring-boot-starter-validation') {
+		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+	}
+
+	implementation 'org.apache.logging.log4j:log4j-api:2.23.1'
+	implementation 'org.apache.logging.log4j:log4j-core:2.23.1'
+	implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.23.1' // Bridge Log4j2 to SLF4J
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	implementation "org.projectlombok:lombok:${lombokVersion}"
@@ -43,18 +54,20 @@ dependencies {
 	implementation 'com.google.cloud:google-cloud-texttospeech:2.38.0'
 	implementation 'com.google.apis:google-api-services-calendar:v3-rev20220715-2.0.0'
 
-	implementation 'org.apache.logging.log4j:log4j-api:2.23.1'
-	implementation 'org.apache.logging.log4j:log4j-core:2.23.1'
-
 	implementation 'org.apache.commons:commons-lang3:3.14.0'
 
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
+	// Dependencies for the device library and PI4J
+	// Excluding the Google protobuf from the Schema library since it clashes with another library
+	// The device library uses JSON exclusively so this is not an issue
 	implementation "com.pi4j:pi4j-core:${pi4jVersion}"
 	implementation "com.pi4j:pi4j-plugin-raspberrypi:${pi4jVersion}"
 	implementation 'io.mapsmessaging:device_library:1.0.9-SNAPSHOT'
-
-	//implementation 'io.mapsmessaging:schemas:2.1.4'
+	implementation 'io.mapsmessaging:simple_logging:2.0.13-SNAPSHOT'
+	implementation ('io.mapsmessaging:schemas:2.1.5-SNAPSHOT'){
+		exclude group: 'com.google.protobuf', module: 'protobuf-java'
+	}
 
 }
 

--- a/src/main/java/fr/terisse/api/notifsapi/services/BME688SensorManager.java
+++ b/src/main/java/fr/terisse/api/notifsapi/services/BME688SensorManager.java
@@ -1,0 +1,125 @@
+package fr.terisse.api.notifsapi.services;
+
+import io.mapsmessaging.devices.DeviceBusManager;
+import io.mapsmessaging.devices.i2c.I2CBusManager;
+import io.mapsmessaging.devices.i2c.I2CDevice;
+import io.mapsmessaging.devices.i2c.I2CDeviceController;
+import io.mapsmessaging.devices.i2c.devices.sensors.bme688.BME688Sensor;
+import io.mapsmessaging.devices.sensorreadings.SensorReading;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Manages the interactions with a BME688 sensor device to retrieve and manage sensor readings
+ * such as gas, temperature, humidity, and pressure.
+ */
+public class BME688SensorManager {
+
+  /**
+   * Holder class for Singleton instance of BME688SensorManager.
+   */
+  private static class Holder {
+    static final BME688SensorManager INSTANCE = new BME688SensorManager();
+  }
+
+  /**
+   * Provides access to the Singleton instance of BME688SensorManager.
+   *
+   * @return The singleton instance of BME688SensorManager.
+   */
+  public static BME688SensorManager getInstance() {
+    return Holder.INSTANCE;
+  }
+
+  private BME688Sensor bme688Sensor;
+
+  SensorReading<?> gas = null;
+  SensorReading<?> temp = null;
+  SensorReading<?> humidity = null;
+  SensorReading<?> pressure = null;
+
+  /**
+   * Private constructor for initializing the BME688SensorManager. Configures the BME688 sensor
+   * on a specified I2C bus.
+   */
+  private BME688SensorManager() {
+    System.setProperty("I2C-PROVIDER", "linuxfs-i2c");
+    I2CBusManager[] i2cBusManagers = DeviceBusManager.getInstance().getI2cBusManager();
+    int bus = 1;
+
+    try {
+      I2CDeviceController deviceController = i2cBusManagers[bus].configureDevice(0x77, "BME688");
+      if (deviceController != null) {
+        I2CDevice sensor = deviceController.getDevice();
+        if (sensor instanceof BME688Sensor) {
+          bme688Sensor = (BME688Sensor) sensor;
+          List<SensorReading<?>> sensorReadingList = bme688Sensor.getReadings();
+          for (SensorReading<?> val : sensorReadingList) {
+            switch (val.getName()) {
+              case "gas":
+                gas = val;
+                break;
+              case "humidity":
+                humidity = val;
+                break;
+              case "pressure":
+                pressure = val;
+                break;
+              case "temperature":
+                temp = val;
+                break;
+            }
+          }
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Checks if there is an error with the gas sensor reading.
+   *
+   * @return true if there is an error, false otherwise.
+   */
+  public boolean hasError(){
+    return gas.getValue().hasError();
+  }
+
+  /**
+   * Retrieves the gas concentration reading from the sensor.
+   *
+   * @return The gas concentration as a float.
+   */
+  public float getGasReading(){
+    return (Float)gas.getValue().getResult();
+  }
+
+  /**
+   * Retrieves the humidity level reading from the sensor.
+   *
+   * @return The humidity level as a float.
+   */
+  public float getHumidityReading(){
+    return (Float)humidity.getValue().getResult();
+  }
+
+  /**
+   * Retrieves the atmospheric pressure reading from the sensor.
+   *
+   * @return The atmospheric pressure as a float.
+   */
+  public float getPressureReading(){
+    return (Float)pressure.getValue().getResult();
+  }
+
+  /**
+   * Retrieves the temperature reading from the sensor.
+   *
+   * @return The temperature as a float.
+   */
+  public float getTemperatureReading(){
+    return (Float)temp.getValue().getResult();
+  }
+}

--- a/src/main/java/fr/terisse/api/notifsapi/services/SensorsSchedulerService.java
+++ b/src/main/java/fr/terisse/api/notifsapi/services/SensorsSchedulerService.java
@@ -1,82 +1,25 @@
 package fr.terisse.api.notifsapi.services;
 
-import io.mapsmessaging.devices.DeviceBusManager;
-import io.mapsmessaging.devices.i2c.I2CBusManager;
-import io.mapsmessaging.devices.i2c.I2CDevice;
-import io.mapsmessaging.devices.i2c.I2CDeviceController;
-import io.mapsmessaging.devices.i2c.I2CDeviceScheduler;
-import io.mapsmessaging.devices.i2c.devices.sensors.bme688.BME688Sensor;
-import io.mapsmessaging.devices.sensorreadings.ComputationResult;
-import io.mapsmessaging.devices.sensorreadings.SensorReading;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-
-import java.io.IOException;
 
 import static io.mapsmessaging.devices.util.Constants.roundFloatToString;
 
 @Service
 public class SensorsSchedulerService {
 
-    @Scheduled(fixedDelay = 10000000)
-    public void testSensors() throws IOException, InterruptedException {
-        System.setProperty("pi4j.provider", "linuxfs-i2c");
-        System.out.println("coucou");
-        I2CBusManager[] i2cBusManagers = DeviceBusManager.getInstance().getI2cBusManager();
-        int bus = 1;
-
-        // Configure and mount a device on address 0x5D as a LPS25 pressure & temperature
-        I2CDeviceController deviceController = i2cBusManagers[bus].configureDevice(0x77, "BME688");
-        if (deviceController != null) {
-
-            System.out.println("coucou1");
-            System.err.println(new String(deviceController.getDeviceConfiguration()));
-            I2CDevice sensor = deviceController.getDevice();
-            if (sensor instanceof BME688Sensor) {
-                BME688Sensor bme688Sensor = (BME688Sensor) sensor;
-
-                SensorReading<?> gas = null;
-                SensorReading<?> temp = null;
-                SensorReading<?> humidity = null;
-                SensorReading<?> pressure = null;
-
-                for (SensorReading<?> val : bme688Sensor.getReadings()) {
-                    switch (val.getName()) {
-                        case "gas":
-                            gas = val;
-                            break;
-                        case "humidity":
-                            humidity = val;
-                            break;
-                        case "pressure":
-                            pressure = val;
-                            break;
-                        case "temperature":
-                            temp = val;
-                            break;
-                    }
-                }
-                long stop = System.currentTimeMillis() + 120_000;
-
-                while (gas != null && humidity != null && temp != null && pressure != null && stop > System.currentTimeMillis()) {
-                    synchronized (I2CDeviceScheduler.getI2cBusLock()) {
-                        ComputationResult<Float> tempResult = (ComputationResult<Float>) temp.getValue();
-                        ComputationResult<Float> gasResult = (ComputationResult<Float>) gas.getValue();
-                        ComputationResult<Float> humResult = (ComputationResult<Float>) humidity.getValue();
-                        ComputationResult<Float> preResult = (ComputationResult<Float>) pressure.getValue();
-                        if (!gasResult.hasError()) {
-                            float gasV = gasResult.getResult();
-                            float tRes = tempResult.getResult();
-                            String pre = roundFloatToString(gasV, 2);
-                            String tmp = roundFloatToString(tRes, 1);
-                            String dis = roundFloatToString(humResult.getResult(), 1);
-                            String pres = roundFloatToString(preResult.getResult(), 1);
-                            System.out.println(pre + " Ohms\t" + tmp + " C\t" + dis + "%"+"\t"+pres+"hPa");
-                            Thread.sleep(1000);
-                        }
-                    }
-                }
-            }
+    @Scheduled(fixedDelay = 1000)
+    public void testSensors() {
+        BME688SensorManager manager = BME688SensorManager.getInstance();
+        if(!manager.hasError()) {
+            String pre = roundFloatToString(manager.getGasReading(), 2);
+            String tmp = roundFloatToString(manager.getTemperatureReading(), 1);
+            String dis = roundFloatToString(manager.getHumidityReading(), 1);
+            String pres = roundFloatToString(manager.getPressureReading(), 1);
+            System.out.println(pre + " Ohms\t" + tmp + " C\t" + dis + "%" + "\t" + pres + "hPa");
+        }
+        else {
+            System.err.println("BME688 in error mode");
         }
     }
 }


### PR DESCRIPTION
The build.grade changes are to exclude logger clashes and protobuf version clashes

The SensorsSchedulerService was changed just to encapsulate the BME688 code to help debug Added a BME688SensorMananger which interfaces between the device library and offers the sensor readings for the BME688 device

Also there is a bug in the get config from the BME688 device. This is not needed to operate but will be fixing it.

Please note, the BME688 takes time to stabilise it's heating sensor and should be read at least every second and takes about 3 to 4 minutes to settle down. There is a mode to enable all heating sensors and if required you can set this by writing to the appropriate registers. Please see [the data sheet](https://www.bosch-sensortec.com/products/environmental-sensors/gas-sensors/bme688/#documents)

Bosch has not exposed the AI mapping of what the resistive reading maps to but has kept in in their library for the arduino or in there own software. This will mean you will need to experiment with the device to understand what the levels actually mean. If I can resolve this with Bosch then the code will also expose it, but not for now.